### PR TITLE
added logout in user profile to amplify auth

### DIFF
--- a/components/UserProfile/UserProfile.tsx
+++ b/components/UserProfile/UserProfile.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { View, Text, StyleSheet, Pressable, Image } from "react-native";
+import { Auth } from "aws-amplify";
+import { UserProfileProps } from "../../route-settings";
 import UserProfileCell from "./UserProfileCell";
 import BackButton from "./BackButton";
 
@@ -71,19 +73,13 @@ const styles = StyleSheet.create({
 
 function LogoutCell() {
   return (
-    <Pressable
-      onPress={() => {
-        console.log("Logout");
-      }}
-    >
-      <View style={[styles.logoutCell, styles.shadow]}>
-        <Text style={styles.logout}>Log Out</Text>
-      </View>
-    </Pressable>
+    <View style={[styles.logoutCell, styles.shadow]}>
+      <Text style={styles.logout}>Log Out</Text>
+    </View>
   );
 }
 
-export default function UserProfile() {
+export default function UserProfile({ navigation }: UserProfileProps) {
   return (
     <View style={styles.container}>
       <BackButton />
@@ -94,7 +90,18 @@ export default function UserProfile() {
         <UserProfileCell title="My Reviews" />
         <UserProfileCell title="Edit Profile" />
         <UserProfileCell title="Notifications" />
-        <LogoutCell />
+        <Pressable
+          onPress={async () => {
+            try {
+              await Auth.signOut();
+              navigation.navigate("Login");
+            } catch (error) {
+              console.error("error signing out: ", error);
+            }
+          }}
+        >
+          <LogoutCell />
+        </Pressable>
       </View>
     </View>
   );

--- a/route-settings.tsx
+++ b/route-settings.tsx
@@ -22,6 +22,7 @@ export type RootStackParamList = {
   ForgotPass2: { email: string };
   ViewCollection: undefined;
   OpenCollection: { name: string; description: string };
+  UserProfile: undefined;
 };
 
 export type LoginProps = NativeStackScreenProps<RootStackParamList, "Login">;
@@ -64,6 +65,10 @@ export type ProfileProps = BottomTabScreenProps<RootTabBarParamList, "Profile">;
 export type ProfileEditorProps = BottomTabScreenProps<
   RootTabBarParamList,
   "ProfileEditor"
+>;
+export type UserProfileProps = NativeStackScreenProps<
+  RootStackParamList,
+  "UserProfile"
 >;
 
 export const TabBarScreenOptions = ({


### PR DESCRIPTION
one thing I noticed was that when I logged out the email and password text was still there. I assume this happens with most of our text fields, so I can change it so that the login pages clear the input after they leave the page, but it would take some refactoring. We can talk more about it later